### PR TITLE
Fix typos and some style fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ Note that this lint uses `golang.org/x/tools`, so all the usual wildcards to fil
 On the following lines, you can see an example of output of this lint:
 
 ```
-mixed_locks.go:[27] Mutex lock is adquired on this line: m.Test()
-	mixed_locks.go:[24] But the same lock was acquired here: m.m.Lock()
+mixed_locks.go:27: Mutex lock is acquired on this line: m.Test()
+	mixed_locks.go:24: But the same lock was acquired here: m.m.Lock()
 ```
 
-The first line indicates where the recursive lock is adquired (so, the second `Lock` on the same goroutine), the file and line where it occurs. The second one, indicate where the first `Lock` occurs
+The first line indicates where the recursive lock is acquired (so, the second `Lock` on the same goroutine), the file and line where it occurs. The second one, indicate where the first `Lock` occurs
 
 ## Exit code
 
@@ -82,7 +82,7 @@ func B(m *sync.RWMutex) {
 }
 ```
 
-There is no techincal limitation (as far as I am aware) to track when a mutex is moved, but I left this cases for now. Feel free to do the change and open a PR to include this case.
+There is no technical limitation (as far as I am aware) to track when a mutex is moved, but I left this cases for now. Feel free to do the change and open a PR to include this case.
 
 Finally, all the analysis is done per package. If there's some recursive `RLock` which operates among distinct packages, it won't be detected by this lint.
 

--- a/mulint/analyzer.go
+++ b/mulint/analyzer.go
@@ -83,7 +83,7 @@ func (a *Analyzer) checkCallToFuncWhichLocksSameMutex(seq *MutexScope, callExpr 
 	if err == nil {
 		fqn := FromCallInfo(pkg, name)
 
-		if a.hasTransitiveCall(fqn, seq, make(map[FQN]bool)) == true {
+		if a.hasTransitiveCall(fqn, seq, make(map[FQN]bool)) {
 			a.recordError(seq.Pos(), callExpr.Pos())
 		}
 	}
@@ -97,7 +97,7 @@ func (a *Analyzer) hasAnyMutexScopeWithSameSelector(fqn FQN, seq *MutexScope) bo
 	}
 
 	for _, currentMutexScope := range mutexScopes.Scopes() {
-		if currentMutexScope.IsEqual(seq) == true {
+		if currentMutexScope.IsEqual(seq) {
 			return true
 		}
 	}
@@ -137,7 +137,7 @@ func (a *Analyzer) checkLockToSequenceMutex(seq *MutexScope, callExpr *ast.CallE
 	}
 }
 
-func (a *Analyzer) recordError(origin token.Pos, secondLock token.Pos) {
+func (a *Analyzer) recordError(origin, secondLock token.Pos) {
 	originLoc := NewLocation(origin)
 	secondLockLoc := NewLocation(secondLock)
 

--- a/mulint/fqn.go
+++ b/mulint/fqn.go
@@ -7,6 +7,6 @@ import (
 
 type FQN string
 
-func FromCallInfo(pkg string, fnName string) FQN {
+func FromCallInfo(pkg, fnName string) FQN {
 	return FQN(strings.Trim(fmt.Sprintf("%s:%s", pkg, fnName), "*"))
 }

--- a/mulint/helpers.go
+++ b/mulint/helpers.go
@@ -70,7 +70,7 @@ func RootSelector(sel *ast.SelectorExpr) *ast.Ident {
 
 func SelectorExpr(call *ast.CallExpr) *ast.SelectorExpr {
 	switch exp := call.Fun.(type) {
-	case (*ast.SelectorExpr):
+	case *ast.SelectorExpr:
 		return exp
 	default:
 	}

--- a/mulint/report.go
+++ b/mulint/report.go
@@ -36,7 +36,7 @@ func (le LintError) Report(pass *analysis.Pass) {
 	originLine := le.GetLine(pass, originLockPosition)
 
 	pass.Reportf(le.secondLock.Pos(),
-		"Mutex lock is acquired on this line: %s\n\t%s:[%d] But the same lock was acquired here: %s\n",
+		"Mutex lock is acquired on this line: %s\n\t%s:%d: But the same lock was acquired here: %s\n",
 		strings.TrimSpace(secondLockLine),
 		le.baseFilename(originLockPosition.Filename),
 		originLockPosition.Line,

--- a/mulint/report.go
+++ b/mulint/report.go
@@ -36,7 +36,7 @@ func (le LintError) Report(pass *analysis.Pass) {
 	originLine := le.GetLine(pass, originLockPosition)
 
 	pass.Reportf(le.secondLock.Pos(),
-		"Mutex lock is adquired on this line: %s\n\t%s:[%d] But the same lock was acquired here: %s\n",
+		"Mutex lock is acquired on this line: %s\n\t%s:[%d] But the same lock was acquired here: %s\n",
 		strings.TrimSpace(secondLockLine),
 		le.baseFilename(originLockPosition.Filename),
 		originLockPosition.Line,

--- a/mulint/visitor.go
+++ b/mulint/visitor.go
@@ -49,7 +49,6 @@ type Scopes struct {
 	defers   map[string]bool
 	finished []*MutexScope
 	prog     *loader.Program
-	pkg      *loader.PackageInfo
 }
 
 func NewScopes(prog *loader.Program) *Scopes {
@@ -96,7 +95,7 @@ func (s *Scopes) Track(stmt ast.Stmt) {
 }
 
 func (s *Scopes) EndBlock() {
-	for k, _ := range s.defers {
+	for k := range s.defers {
 		if og, ok := s.onGoing[k]; ok {
 			s.finished = append(s.finished, og)
 		}
@@ -126,9 +125,9 @@ func (s *Scopes) isDeferUnlockCall(node ast.Node) ast.Expr {
 	switch sty := node.(type) {
 	case *ast.DeferStmt:
 		return s.isUnlockCall(sty.Call)
+	default:
+		return nil
 	}
-
-	return nil
 }
 
 type Visitor struct {
@@ -186,7 +185,7 @@ func (v *Visitor) recordCalls(currentFQN FQN, body *ast.BlockStmt) {
 	}
 }
 
-func (v *Visitor) addCall(from FQN, to FQN) {
+func (v *Visitor) addCall(from, to FQN) {
 	_, ok := v.calls[from]
 	if !ok {
 		v.calls[from] = make([]FQN, 0)

--- a/tests/mixed_locks.go
+++ b/tests/mixed_locks.go
@@ -24,10 +24,10 @@ func (m *mixed) TestFail() {
 	m.m.Lock()
 	defer m.m.Unlock()
 
-	m.Test() // want "Mutex lock is adquired on this line"
+	m.Test() // want "Mutex lock is acquired on this line"
 }
 
-func (m *mixed) Interlevead() {
+func (m *mixed) Interleaved() {
 	m.m.Lock()
 	m.m2.Lock()
 	m.m.Unlock()

--- a/tests/simple_rlock.go
+++ b/tests/simple_rlock.go
@@ -12,6 +12,6 @@ func (a *another) Test() {
 	a.m.RLock()
 	defer a.m.RUnlock()
 
-	a.m.Lock() // want "Mutex lock is adquired on this line"
+	a.m.Lock() // want "Mutex lock is acquired on this line"
 	a.m.Unlock()
 }

--- a/tests/transitive_lock.go
+++ b/tests/transitive_lock.go
@@ -20,8 +20,8 @@ func (s *some) Entry() {
 
 	s.sm["lalala"] = 2
 	noneStructMethod()
-	s.recursiveRLock() // want "Mutex lock is adquired on this line"
-	s.deepLock()       // want "Mutex lock is adquired on this line"
+	s.recursiveRLock() // want "Mutex lock is acquired on this line"
+	s.deepLock()       // want "Mutex lock is acquired on this line"
 }
 
 func (s *some) ShouldNotDetectDeadLock() {


### PR DESCRIPTION
* Fixed some typos
* Some code style fixes (I did a crazy thing and ran a linter on this!)
* Changed the line format of the second line to `transitive_lock.go:18:` (was `transitive_lock.go[18]`) to be the same as the first line and the usual line format of other tools